### PR TITLE
ReportDefinition creation support

### DIFF
--- a/bin/gdc
+++ b/bin/gdc
@@ -561,7 +561,7 @@ sub help
 	die 'Extra arguments' if @_;
 
 	print map { "$_\n" } 'Valid commands: ',
-		map { "\t$_" } keys %actions ;
+		map { "\t$_" } sort keys %actions ;
 }
 
 login ($user, $password ? "$password" : undef) if defined $user;

--- a/bin/gdc
+++ b/bin/gdc
@@ -573,6 +573,10 @@ Descriptive summary of the object.
 
 Expression (typically MAQL).
 
+=item B<-u>, B<--uri>
+
+Instead of creating a new object, rewrite an old one with a given URI.
+
 =item B<-P>, B<--project>
 
 Set or override the project to act on.
@@ -585,6 +589,7 @@ See global B<--project> option for the detailed description.
 sub mkobject
 {
 	my $project = $project;
+	my $uri;
 	my $type;
 	my $title;
 	my $summary = '';
@@ -596,6 +601,7 @@ sub mkobject
 		's|summary=s' => \$summary,
 		'e|expr=s' => \$expression,
 		'P|project=s' => \$project,
+		'u|uri=s' => \$uri,
 	) or die 'Bad arguments to mkobject';
 	$type = shift if @_;
 	$title = shift if @_;
@@ -603,7 +609,7 @@ sub mkobject
 	die 'Extra arguments' if @_;
 	die 'No project URI given' unless defined $project;
 
-	print $gdc->create_object_with_expression ($project, $type, $title,
+	print $gdc->create_object_with_expression ($project, $uri, $type, $title,
 		$summary, $expression) . "\n";
 }
 
@@ -633,6 +639,10 @@ Add an attribute to dimensionality by its URL.
 
 Add a filter by its expression.
 
+=item B<-u>, B<--uri>
+
+Instead of creating a new object, rewrite an old one with a given URI.
+
 =item B<-P>, B<--project>
 
 Set or override the project to act on.
@@ -645,6 +655,7 @@ See global B<--project> option for the detailed description.
 sub mkreportdef
 {
 	my $project = $project;
+	my $uri;
 	my $title;
 	my $summary = '';
 	my $metrics;
@@ -658,14 +669,15 @@ sub mkreportdef
 		'm|metric=s@' => \$metrics,
 		'd|dim=s@' => \$dim,
 		'f|filter=s@' => \$filters,
+		'u|uri=s' => \$uri,
 	) or die 'Bad arguments to mkreportdef';
 	$title = shift if @_;
 	$summary = shift if @_;
 	die 'Extra arguments' if @_;
 	die 'No project URI given' unless defined $project;
 
-	print $gdc->create_report_definition ($project, $title, $summary, $metrics,
-		$dim, $filters ) . "\n";
+	print $gdc->create_report_definition ($project, $uri, $title, $summary,
+		$metrics, $dim, $filters ) . "\n";
 }
 
 =head2 help

--- a/bin/gdc
+++ b/bin/gdc
@@ -100,6 +100,8 @@ my %actions = (
 	model => \&model,
 	chmodel => \&chmodel,
 	upload => \&upload,
+	mkobject => \&mkobject,
+	mkreportdef => \&mkreportdef,
 	help => \&help,
 	shell => \&shell,
 );
@@ -546,6 +548,124 @@ sub upload
 	die 'No project URI given' unless defined $project;
 	die 'No SLI manifest given' unless defined $file;
 	$gdc->upload ($project, $file)
+}
+
+=head2 mkobject <type> <title> <expression>
+
+Create a new metadata object of a given type with expression as the only
+content.
+
+=over 4
+
+=item B<-T>, B<--type>
+
+Type of the object.
+
+=item B<-t>, B<--title>
+
+Title of the object.
+
+=item B<-s>, B<--summary>
+
+Descriptive summary of the object.
+
+=item B<-e>, B<--expr>
+
+Expression (typically MAQL).
+
+=item B<-P>, B<--project>
+
+Set or override the project to act on.
+See global B<--project> option for the detailed description.
+
+=back
+
+=cut
+
+sub mkobject
+{
+	my $project = $project;
+	my $type;
+	my $title;
+	my $summary = '';
+	my $expression;
+
+	GetOptionsFromArray (\@_,
+		'T|type=s' => \$type,
+		't|title=s' => \$title,
+		's|summary=s' => \$summary,
+		'e|expr=s' => \$expression,
+		'P|project=s' => \$project,
+	) or die 'Bad arguments to mkobject';
+	$type = shift if @_;
+	$title = shift if @_;
+	$expression = shift if @_;
+	die 'Extra arguments' if @_;
+	die 'No project URI given' unless defined $project;
+
+	print $gdc->create_object_with_expression ($project, $type, $title,
+		$summary, $expression) . "\n";
+}
+
+=head2 mkreportdef <title> [summary]
+
+Create a new reportDefinition in metadata.
+
+=over 4
+
+=item B<-t>, B<--title>
+
+Title of the object.
+
+=item B<-s>, B<--summary>
+
+Descriptive summary of the object.
+
+=item B<-m>, B<--metric>
+
+Add a metric by its URL.
+
+=item B<-d>, B<--dim>
+
+Add an attribute to dimensionality by its URL.
+
+=item B<-f>, B<--filter>
+
+Add a filter by its expression.
+
+=item B<-P>, B<--project>
+
+Set or override the project to act on.
+See global B<--project> option for the detailed description.
+
+=back
+
+=cut
+
+sub mkreportdef
+{
+	my $project = $project;
+	my $title;
+	my $summary = '';
+	my $metrics;
+	my $dim;
+	my $filters;
+
+	GetOptionsFromArray (\@_,
+		't|title=s' => \$title,
+		's|summary=s' => \$summary,
+		'P|project=s' => \$project,
+		'm|metric=s@' => \$metrics,
+		'd|dim=s@' => \$dim,
+		'f|filter=s@' => \$filters,
+	) or die 'Bad arguments to mkreportdef';
+	$title = shift if @_;
+	$summary = shift if @_;
+	die 'Extra arguments' if @_;
+	die 'No project URI given' unless defined $project;
+
+	print $gdc->create_report_definition ($project, $title, $summary, $metrics,
+		$dim, $filters ) . "\n";
 }
 
 =head2 help

--- a/lib/WWW/GoodData.pm
+++ b/lib/WWW/GoodData.pm
@@ -520,7 +520,7 @@ sub poll
         return undef;
 }
 
-=item B<create_object_with_expression> PROJECT TYPE TITLE SUMMARY EXPRESSION
+=item B<create_object_with_expression> PROJECT URI TYPE TITLE SUMMARY EXPRESSION
 
 Create a new metadata object of type TYPE with EXPRESSION as the only content.
 
@@ -530,13 +530,20 @@ sub create_object_with_expression
 {
 	my $self = shift;
 	my $project = shift;
+	my $uri = shift;
 	my $type = shift or die 'No type given';
 	my $title = shift or die 'No title given';
 	my $summary = shift || '';
 	my $expression = shift or die 'No expression given';
 
+	if (defined $uri) {
+		$uri = new URI ($uri);
+	} else {
+		$uri = $self->get_uri (new URI ($project), qw/metadata obj/);
+	}
+
 	return $self->{agent}->post (
-		$self->get_uri (new URI ($project), qw/metadata obj/),
+		$uri,
 		{ $type => {
 			content => {
 				expression => $expression
@@ -549,7 +556,7 @@ sub create_object_with_expression
 	)->{uri};
 }
 
-=item B<create_report_definition> PROJECT TITLE SUMMARY METRICS DIM FILTERS
+=item B<create_report_definition> PROJECT URI TITLE SUMMARY METRICS DIM FILTERS
 
 Create a new reportDefinition in metadata.
 
@@ -559,14 +566,21 @@ sub create_report_definition
 {
 	my $self = shift;
 	my $project = shift;
+	my $uri = shift;
 	my $title = shift or die 'No title given';
 	my $summary = shift || '';
 	my $metrics = shift || [];
 	my $dim = shift || [];
 	my $filters = shift || [];
 
+	if (defined $uri) {
+		$uri = new URI ($uri);
+	} else {
+		$uri = $self->get_uri (new URI ($project), qw/metadata obj/);
+	}
+
 	return $self->{agent}->post (
-		$self->get_uri (new URI ($project), qw/metadata obj/),
+		$uri,
 		{ reportDefinition => {
 			content => {
 				filters => [ map +{ expression => $_ }, @$filters ],

--- a/lib/WWW/GoodData.pm
+++ b/lib/WWW/GoodData.pm
@@ -520,6 +520,77 @@ sub poll
         return undef;
 }
 
+=item B<create_object_with_expression> PROJECT TYPE TITLE SUMMARY EXPRESSION
+
+Create a new metadata object of type TYPE with EXPRESSION as the only content.
+
+=cut
+
+sub create_object_with_expression
+{
+	my $self = shift;
+	my $project = shift;
+	my $type = shift or die 'No type given';
+	my $title = shift or die 'No title given';
+	my $summary = shift || '';
+	my $expression = shift or die 'No expression given';
+
+	return $self->{agent}->post (
+		$self->get_uri (new URI ($project), qw/metadata obj/),
+		{ $type => {
+			content => {
+				expression => $expression
+			},
+			meta => {
+				summary => $summary,
+				title => $title,
+			}
+		}}
+	)->{uri};
+}
+
+=item B<create_report_definition> PROJECT TITLE SUMMARY METRICS DIM FILTERS
+
+Create a new reportDefinition in metadata.
+
+=cut
+
+sub create_report_definition
+{
+	my $self = shift;
+	my $project = shift;
+	my $title = shift or die 'No title given';
+	my $summary = shift || '';
+	my $metrics = shift || [];
+	my $dim = shift || [];
+	my $filters = shift || [];
+
+	return $self->{agent}->post (
+		$self->get_uri (new URI ($project), qw/metadata obj/),
+		{ reportDefinition => {
+			content => {
+				filters => [ map +{ expression => $_ }, @$filters ],
+				grid => {
+					columns => [ "metricGroup" ],
+					metrics => [ map +{ alias => '', uri => $_ }, @$metrics ],
+					rows => [ map +{ attribute => { alias => '', uri => $_,
+						totals => [[]] } }, @$dim ],
+					sort => {
+						columns => [],
+						rows => [],
+					},
+					columnWidths => []
+				},
+				format => "grid"
+			},
+			meta => {
+				summary => $summary,
+				title => $title,
+			}
+		}}
+	)->{uri};
+}
+
 =item B<DESTROY>
 
 Log out the session with B<logout> unless not logged in.


### PR DESCRIPTION
Example:

```
$  gdc -P /gdc/projects/FoodMartDemo
> mkobject metric "Pokus" 'SELECT SUM([/gdc/md/FoodMartDemo/obj/5003]) WHERE [/gdc/md/FoodMartDemo/obj/6025] IN ([/gdc/md/FoodMartDemo/obj/6025/elements?id=7],[/gdc/md/FoodMartDemo/obj/6025/elements?id=8]) WITHOUT PF'
/gdc/md/FoodMartDemo/obj/130004304
> mkreportdef "PokusReport" -m /gdc/md/FoodMartDemo/obj/130004304 -d /gdc/md/FoodMartDemo/obj/6025 -f '[/gdc/md/FoodMartDemo/obj/6025] IN ([/gdc/md/FoodMartDemo/obj/6025/elements?id=7])'
/gdc/md/FoodMartDemo/obj/130004312
```
