### PR TITLE
Fix - creation of report definitions without metrics

### DIFF
--- a/lib/WWW/GoodData.pm
+++ b/lib/WWW/GoodData.pm
@@ -684,7 +684,7 @@ sub create_report_definition
 			content => {
 				filters => [ map +{ expression => $_ }, @$filters ],
 				grid => {
-					columns => [ "metricGroup" ],
+					columns => [ @$metrics ? "metricGroup" : () ],
 					metrics => [ map +{ alias => '', uri => $_ }, @$metrics ],
 					rows => [ map +{ attribute => { alias => '', uri => $_,
 						totals => [[]] } }, @$dim ],


### PR DESCRIPTION
Když vyrobíš report definici bez metrik, tak nejde exekuovat a zobrazit výsledek - důvod je, že tam očekává metricGroup, ale žádné metriky tam nejsou. Proto je třeba malý ifík.
